### PR TITLE
...

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ Enable clickable links in Mudlet! That's pretty nice, right?
 
 ## License
 
-`clicker` is released into the public domain under the [0BSD](LICENSE.txt).
+`clicker` is released under the [0BSD](LICENSE.txt).


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes a minor documentation update to `README.md`, removing the phrase "into the public domain" from the license statement so it reads "released under the [0BSD]" instead of "released into the public domain under the [0BSD]". This is a technically more accurate description, as 0BSD is a license (albeit an extremely permissive one often considered a public-domain equivalent) rather than a formal public domain dedication.

- Removes "into the public domain" from the license blurb in `README.md` for improved accuracy

<h3>Confidence Score: 5/5</h3>

Single-line README documentation tweak with no code impact — safe to merge immediately.

The change is a one-word removal from a markdown file with no functional or logical implications. No code, tests, or configuration are affected.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["..."](https://github.com/gesslar/clicker/commit/c4de1a5793708e0eedee029304fab4703c540ef5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27961487)</sub>

<!-- /greptile_comment -->